### PR TITLE
Added a script for resubmitting a project on intra + minor changes.

### DIFF
--- a/exams/create_exam.py
+++ b/exams/create_exam.py
@@ -75,6 +75,11 @@ choices = [
 exam_choice = int(input(f"{Fore.YELLOW}Type in your choice from 0-4: "))
 print(f"{Fore.CYAN}You have chosen {choices[exam_choice][1]}")
 
+# Check for DO NOT SUBSCRIBE anomalies.
+ans = input(f"{Fore.YELLOW}Is this a DO NOT SUBSCRIBE session? (Y if yes, otherwise no): ")
+if ans == "Y":
+	choices[exam_choice][1] = "DO NOT SUBSCRIBE"
+
 # Get the location of the exam. Defaults to 42KL Campus
 exam_location = input(f"{Fore.YELLOW}Type in the exam location (default is 42KL Campus): ")
 if (exam_location == ""):
@@ -82,16 +87,24 @@ if (exam_location == ""):
 
 # Get the starting time and duration of the exam. Get the time in Malaysian time, and adjust to Paris time
 # Paris time = Malaysia time - 8 hours
-raw_date = input(f"{Fore.YELLOW}Type in the start date of the exam in the format DD/MM/YYYY, e.g 18/3/2024: ")
-raw_time = input(f"{Fore.YELLOW}Type in the start time of the exam in the format HH:MM, e.g. 14:30: ")
 
-# Auto fit duration based on choice, but ask just in case.
+# Auto fit duration and time based on choice, but ask just in case.
 if exam_choice == 3:
 	default_duration = 8
+	default_time = "10:30"
 elif exam_choice in [4, 5]:
 	default_duration = 3
+	default_time = "14:00"
 else:
 	default_duration = 4
+	default_time = "14:30"
+
+raw_date = input(f"{Fore.YELLOW}Type in the start date of the exam in the format DD/MM/YYYY, e.g 18/3/2024: ")
+
+# Start time must be in the format of HH:MM, e.g. 9:00 or 15:30
+raw_time = input(f"{Fore.YELLOW}Type in the start time of the exam (default is {default_time}): ")
+if (raw_time == ""):
+	raw_time = default_time
 
 duration = input(f"{Fore.YELLOW}Type in the number of hours the exam will take (default is {default_duration} hours): ")
 if (duration == ""):

--- a/teams/get_teams_of_user.py
+++ b/teams/get_teams_of_user.py
@@ -1,0 +1,52 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+import os
+import colorama
+from colorama import Fore
+import json
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+# user_id = 172791
+user_id = "jthor"
+
+params = {
+	"page": {
+		"size": 100
+    }
+}
+
+response = oauth.get(f"{SITE}/v2/users/{user_id}/teams", json=params)
+
+# Print response status and content
+if (response.status_code == 200):
+	color = Fore.GREEN
+else:
+	color = Fore.RED
+print(f"{color} {response.text}")
+
+data = json.loads(response.text)
+
+json_obj = json.dumps(data, indent=4)
+with open(f"teams_of_{user_id}.json", "w") as outfile:
+	outfile.write(json_obj)

--- a/teams/reset_team_uploads.py
+++ b/teams/reset_team_uploads.py
@@ -1,0 +1,38 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+import os
+import colorama
+from colorama import Fore
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+teams_id = 5564534
+
+response = oauth.post(f"{SITE}/v2/teams/{teams_id}/reset_team_uploads")
+
+# Print response status and content
+if (response.status_code == 200):
+	color = Fore.GREEN
+else:
+	color = Fore.RED
+print(f"{color} {response.text}")

--- a/teams/reset_team_uploads.py
+++ b/teams/reset_team_uploads.py
@@ -3,11 +3,14 @@ from requests_oauthlib import OAuth2Session
 from dotenv import load_dotenv
 import os
 import colorama
+import json
 from colorama import Fore
 
 colorama.init(autoreset=True)
 
 load_dotenv()
+
+# Just run the script, all inputs are prompted.
 
 # Yay API token stuff
 UID = os.getenv("42-UID")
@@ -26,11 +29,72 @@ token = oauth.fetch_token(
 	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
 )
 
-teams_id = 5564534
+# Due to how the API call is, it is necessary to use a GET request for the teams_id of the
+# affected Cadet/Pisciner. We will use the one that is documented under "GET /v2/users/:user_id/teams"
+# in the 42 API Official Documentation.
 
-response = oauth.post(f"{SITE}/v2/teams/{teams_id}/reset_team_uploads")
+# Get the teams (details of all submitted and current projects) of the user.
+user_id = input(f"{Fore.YELLOW}Type in the user: ").lower()
 
-# Print response status and content
+params = {
+	"page": {
+		"size": 20
+	},
+	"sort": "-id"
+}
+get_response = oauth.get(f"{SITE}/v2/users/{user_id}/teams", json=params)
+
+if (get_response.status_code == 200):
+	print(f"{Fore.GREEN}User {user_id} found!" + '\n')
+else:
+	print(f"{Fore.RED}User {user_id} is not found!")
+	raise (Exception("User with intra ID is not found."))
+
+# From the list, take the 5 most recent submitted and Momo-graded projects that are not exams
+# and create an options array for which one to reset
+
+data = json.loads(get_response.text)
+count = 0
+options = []
+default_option = -1
+
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^15}+{'':-^15}+{'':-^7}+")
+print(f"{Fore.CYAN}|{'INDEX': ^7}|{'PROJECT': ^15}|{'TEAM_ID': ^15}|{'NORME': ^7}|")
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^15}+{'':-^15}+{'':-^7}+")
+
+for item in data:
+	if count == 5:
+		break
+	if item['status'] != 'finished' or item['project_gitlab_path'] is None or len(item['teams_uploads']) == 0:
+		continue
+	proj_name = item['project_gitlab_path'].split('/')[-1]
+	norme_count = len([1 for x in item['teams_uploads'][0]['comment'].split('|') if "Norme" in x or "Norm" in x])
+	if (norme_count > 0):
+		print(f"{Fore.RED}|{count: ^7}|{proj_name: ^15}|{item['id']: ^15}|{norme_count: ^7}|")
+		if default_option == -1:
+			default_option = count
+	else:
+		print(f"{Fore.CYAN}|{count: ^7}|{proj_name: ^15}|{item['id']: ^15}|{norme_count: ^7}|")
+	options.append([proj_name, item['id']])
+	count += 1
+
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^15}+{'':-^15}+{'':-^7}+" + '\n')
+
+# Decide which option to be parsed into the payload of the POST request.
+if (default_option != -1):
+	choice = input(f"{Fore.YELLOW}Type in the index of the project to resubmit (Default is {default_option}): ")
+	if choice == "":
+		choice = default_option
+	else:
+		choice = int(choice)
+else:
+	choice = int(input(f"{Fore.YELLOW}Type in the index of the project to resubmit: "))
+
+# Confirm payload before sending
+confirmed = input(f"{Fore.RED}[ CONFIRMATION ] - Press Enter to reset {user_id}'s {options[choice][0]} with id {options[choice][1]} ?")
+
+response = oauth.post(f"{SITE}/v2/teams/{options[choice][1]}/reset_team_uploads")
+
 if (response.status_code == 200):
 	color = Fore.GREEN
 else:

--- a/teams_users/get_teams_of_user.py
+++ b/teams_users/get_teams_of_user.py
@@ -18,7 +18,7 @@ if UID == None or SECRET == None:
 	raise (Exception("Env variables are not defined!"))
 
 SITE = "https://api.intra.42.fr"
-SCOPE = "public"
+SCOPE = "public projects"
 
 client = BackendApplicationClient(client_id=UID)
 oauth = OAuth2Session(client=client)
@@ -28,16 +28,15 @@ token = oauth.fetch_token(
 )
 
 # user_id = 172791
-user_id = "damdayan"
+user_id = "habdulla"
 
-# Load 30 "items" in one page.
 params = {
 	"page": {
-		"size": 100
+		"size": 20
     }
 }
 
-response = oauth.get(f"{SITE}/v2/users/{user_id}/teams", json=params)
+response = oauth.get(f"{SITE}/v2/users/{user_id}/teams_users", json=params)
 
 # Print response status and content
 if (response.status_code == 200):
@@ -46,26 +45,24 @@ else:
 	color = Fore.RED
 print(f"{color} {response.status_code}")
 
+# Below is just testing to see how to use the returned response.
 
-# Code below are for testing purposes
-
-# Load response into a JSON array and reverse it to arrange the project list from
-# most recent to least recent.
 data = json.loads(response.text)
-data = data[::-1]
+total = len(data)
 
-# From the reversed list, take the 5 most recent submitted and Momo-graded projects that are not exams
-# and get the project name (project_gitlab_path), id, and Momo's comment to check for Norme anomalies (teams_uploads)
-
+print("Items:\n")
 count = 0
+
+# From the response, extract the 5 most recent submitted projects (status is finished)
+# that are not exams (if exam then project_gitlab_path is None), and display the project
+# gitlab path and final mark.
 for item in data:
 	if count == 5:
 		break
-	if item['status'] != 'finished' or item['project_gitlab_path'] is None or len(item['teams_uploads']) == 0:
+	if item["team"]["status"] != "finished" or item['team']['project_gitlab_path'] is None:
 		continue
-	proj_name = str(item['project_gitlab_path']).split('/')[-1]
-	norme_count = len([1 for x in item['teams_uploads'][0]['comment'].split('|') if 'Norme' in x])
-	print(f"[{count}] : {proj_name} | {item['id']} | {norme_count}")
+	else:
+		print(f"[{count}] : {item['team']['project_gitlab_path']} with {item['team']['final_mark']}%")
 	count += 1
 
 json_obj = json.dumps(data, indent=4)


### PR DESCRIPTION
**exams/create_exam.py**
- Added default suggestions for exam timings based on which exam is being created
- Added option to rename the exam that is to be created to "DO NOT SUBSCRIBE"

**teams/get_teams_of_user.py** & **teams_users/get_teams_of_user.py**
- Added scripts that uses a GET request to retrieve all submitted and ongoing projects of a given user.
- Difference between the two API calls are minimal. The scripts can be run to produce .json files showing the differences.

**teams/reset_team_uploads.py**
- Added a script for resetting project submissions, to be used when Norme bugs out or an unexpected segfault occurs on a submission.