### PR TITLE
New script additions and minor changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 venv
 */**.DS_Store
+*.json

--- a/exam_users/get_exam_users.py
+++ b/exam_users/get_exam_users.py
@@ -1,0 +1,45 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+from datetime import datetime as dt, timedelta
+import os
+import json
+import colorama
+from colorama import Fore
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+# Get ID of the scale teams from running the script exams > get_exams.py
+exam_id = 17844
+
+response = oauth.get(f"{SITE}/v2/exams/{exam_id}/exams_users")
+
+if response.status_code == 200:
+	color = Fore.GREEN
+else:
+	color = Fore.RED
+print(f"{color} {response.status_code} {response.text}")
+
+data = json.loads(response.text)
+
+with open(f"exam_users_for_{exam_id}.json", "w") as outfile:
+	json.dump(data, outfile, indent=4)

--- a/exam_users/get_exam_users.py
+++ b/exam_users/get_exam_users.py
@@ -28,7 +28,7 @@ token = oauth.fetch_token(
 	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
 )
 
-# Get ID of the scale teams from running the script exams > get_exams.py
+# Get ID of the exam from running the script exams > get_exams.py
 exam_id = 17844
 
 response = oauth.get(f"{SITE}/v2/exams/{exam_id}/exams_users")

--- a/exam_users/post_exam_user.py
+++ b/exam_users/post_exam_user.py
@@ -1,0 +1,61 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+from datetime import datetime as dt, timedelta
+import os
+import json
+import colorama
+from colorama import Fore
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+# Get the ID of the user using a simple GET
+intra_id = input(f"{Fore.YELLOW}Type in the intra id of the user: ").lower()
+
+get_student_id = oauth.get(f"{SITE}/v2/users/{intra_id}")
+if (get_student_id.status_code == 200):
+	print(f"{Fore.GREEN}User {intra_id} found!")
+else:
+	print(f"{Fore.RED}User {intra_id} is not found!")
+	raise (Exception("User with intra ID is not found."))
+
+student_data = json.loads(get_student_id.text)
+student_id = student_data["id"]
+
+# Get the ID of the exam, manual for now
+exam_id = 17852
+
+# Build payload
+payload = {
+	"exams_user": {
+		"user_id": student_id
+    }
+}
+
+response = oauth.post(f"{SITE}/v2/exams/{exam_id}/exams_users", json=payload)
+
+if (response.status_code == 201):
+	color = Fore.GREEN
+else:
+	color = Fore.RED
+
+print(f"{color}{response.status_code} {response.text}")

--- a/exam_users/post_exam_user.py
+++ b/exam_users/post_exam_user.py
@@ -41,8 +41,38 @@ else:
 student_data = json.loads(get_student_id.text)
 student_id = student_data["id"]
 
-# Get the ID of the exam, manual for now
-exam_id = 17852
+# Get the ID of the previous 5 exams using GET /v2/campus/:campus_id/exams
+# From there, allow admin to choose which one to register the user for.
+get_exam_req = oauth.get(f"{SITE}/v2/campus/34/exams")
+
+if (get_exam_req.status_code != 200):
+	raise Exception("Error on GET request for /v2/campus/:campus_id/exams")
+
+exam_data = json.loads(get_exam_req.text)
+count = 0
+options = []
+
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^9}|{'':-^35}+{'':-^12}+")
+print(f"{Fore.CYAN}|{'INDEX': ^7}|{'ID': ^9}|{'NAME': ^35}|{'DATE': ^12}|")
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^9}|{'':-^35}+{'':-^12}+")
+
+for item in exam_data:
+	if count == 5:
+		break
+	exam_start = item['begin_at'].split('T')[0]
+	print(f"{Fore.CYAN}|{count: ^7}|{item['id']: ^9}|{item['name']: ^35}|{exam_start: ^12}|")
+	options.append([item['id'], item['name'], exam_start])
+	count += 1
+
+
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^9}|{'':-^35}+{'':-^12}+")
+
+exam_choice = int(input(f"{Fore.YELLOW}Type in the index of the exam to add the student into: "))
+print(f"{Fore.CYAN}Chosen {options[exam_choice][1]} that starts on {options[exam_choice][2]}")
+exam_id = options[exam_choice][0]
+
+# Confirmation
+confirm = input(f"{Fore.RED}[ CONFIRMATION ] - Press Enter to add {intra_id} to the above exam.")
 
 # Build payload
 payload = {

--- a/exams/create_cadet_exam.py
+++ b/exams/create_cadet_exam.py
@@ -1,0 +1,85 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+from datetime import datetime as dt, timedelta
+import os
+import colorama
+import time
+from colorama import Fore
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+# First create dt variables that represent the next Wednesday and next Saturday for the week.
+# This script has to be run on either Sunday, Monday or Tuesday.
+dt_today = dt.now()
+num_to_wed = 3 - int(dt_today.strftime("%w"))
+
+dt_wed = dt_today + timedelta(days=num_to_wed)
+dt_sat = dt_wed + timedelta(days=3)
+
+wed_start = dt_wed.strftime("%Y-%m-%dT06:00:00.000Z")
+wed_end = dt_wed.strftime("%Y-%m-%dT09:00:00.000Z")
+sat_start = dt_sat.strftime("%Y-%m-%dT06:00:00.000Z")
+sat_end = dt_sat.strftime("%Y-%m-%dT09:00:00.000Z")
+
+# Get exam location
+exam_location = input("Type in the exam location (Default is Unit 181GF): ")
+if (exam_location == ""):
+	exam_location = "Unit 181GF"
+
+payloads = [
+	{
+		"exam": {
+			"name": "Cadet Ranking Exam",
+			"begin_at": wed_start,
+			"end_at": wed_end,
+			"location": exam_location,
+			"ip_range": "10.11.0.0/16,10.12.0.0/16, 10.13.0.0/16, 10.14.0.0/16, 10.15.0.0/16",
+			"campus_id": "34",
+			"activate_waitlist": "false",
+			"project_ids": [1320, 1321, 1322, 1323, 1324]
+		}
+	},
+	{
+		"exam": {
+			"name": "Cadet Ranking Exam",
+			"begin_at": sat_start,
+			"end_at": sat_end,
+			"location": exam_location,
+			"ip_range": "10.11.0.0/16,10.12.0.0/16, 10.13.0.0/16, 10.14.0.0/16, 10.15.0.0/16",
+			"campus_id": "34",
+			"activate_waitlist": "false",
+			"project_ids": [1320, 1321, 1322, 1323, 1324]
+		}
+	}
+]
+
+for payload in payloads:
+	response = oauth.post(f"{SITE}/v2/exams", json=payload)
+
+	if (response.status_code == 201):
+		color = Fore.GREEN
+	else:
+		color = Fore.RED
+	print(f"{color} {response.text}")
+
+	time.sleep(0.5)

--- a/exams/create_exam.py
+++ b/exams/create_exam.py
@@ -85,6 +85,14 @@ exam_location = input(f"{Fore.YELLOW}Type in the exam location (default is 42KL 
 if (exam_location == ""):
 	exam_location = "42KL Campus"
 
+# Ask if the exam is to be invisible
+invis = input("Is the exam meant to be invisible? Y if yes, no otherwise.")
+if invis == "Y":
+	choices[exam_choice][1] += " (INVISIBLE)"
+	vis_state = "false"
+else:
+	vis_state = "true"
+
 # Get the starting time and duration of the exam. Get the time in Malaysian time, and adjust to Paris time
 # Paris time = Malaysia time - 8 hours
 
@@ -120,6 +128,7 @@ parsed_end = parsed_start + timedelta(hours=duration)
 final_start = parsed_start.strftime("%Y-%m-%dT%H:%M:00.000Z")
 final_end = parsed_end.strftime("%Y-%m-%dT%H:%M:00.000Z")
 
+
 # Confirm payload before sending
 print(f"{Fore.CYAN}\nSimulated payload - Check for final details")
 print(f"{Fore.CYAN}name : {choices[exam_choice][1]}")
@@ -128,6 +137,7 @@ print(f"{Fore.CYAN}end_at : {final_end}")
 print(f"{Fore.CYAN}location : {exam_location}")
 print(f"{Fore.CYAN}ip_range : \"10.11.0.0/16,10.12.0.0/16,10.13.0.0/16,10.14.0.0/16,10.15.0.0/16\"")
 print(f"{Fore.CYAN}campus_id : 34")
+print(f"{Fore.CYAN}visible: {vis_state}")
 print(f"{Fore.CYAN}project_ids : {choices[exam_choice][0]}")
 
 print(f"\n{Fore.RED}CONFIRMATION")
@@ -144,6 +154,7 @@ payload = {
 		"ip_range": "10.11.0.0/16,10.12.0.0/16, 10.13.0.0/16, 10.14.0.0/16, 10.15.0.0/16",
 		"campus_id": "34",
 		"ativate_waitlist": "false",
+		"visible": vis_state,
 		"project_ids": choices[exam_choice][0]
 	}
 }

--- a/exams/get_exams_by_campus.py
+++ b/exams/get_exams_by_campus.py
@@ -28,10 +28,10 @@ token = oauth.fetch_token(
 
 response = oauth.get(f"{SITE}/v2/campus/34/exams")
 
-# color = Fore.GREEN
-# if int(response.status_code) != 200:
-# 	color = Fore.RED
-# print(f"{color} {response.status_code} {response.text}")
+color = Fore.GREEN
+if int(response.status_code) != 200:
+	color = Fore.RED
+print(f"{color} {response.status_code}")
 
 data = json.loads(response.text)
 
@@ -39,5 +39,5 @@ data = json.loads(response.text)
 
 json_obj = json.dumps(data, indent=4)
 
-with open("exams.json", "w") as outfile:
+with open("exams_of_campus_34.json", "w") as outfile:
 	outfile.write(json_obj)

--- a/experiences/get_experiences_of_user.py
+++ b/experiences/get_experiences_of_user.py
@@ -1,0 +1,51 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+import os
+import colorama
+from colorama import Fore
+import json
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+# Using a user_id, receive a list of exp received per submission.
+user_id = "zyeoh"
+
+params = {
+	"page": {
+		"size": 100
+    }
+}
+
+response = oauth.get(f"{SITE}/v2/users/{user_id}/experiences")
+
+if response.status_code == 200:
+	color = Fore.GREEN
+else:
+	color = Fore.RED
+
+print(f"{color}{response.status_code}")
+
+data = json.loads(response.text)
+
+with open("new_test.json", "w") as outfile:
+	json.dump(data, outfile, indent=4)

--- a/scale-teams/create_eval_session.py
+++ b/scale-teams/create_eval_session.py
@@ -28,19 +28,6 @@ token = oauth.fetch_token(
 	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
 )
 
-# payload = {}
-# payload["scale_teams"] = []
-
-# team_id = input("Input the team id: ")
-# evaluator_id = input("Input the id of the evaluator: ")
-# begin_at = "2024-04-11T12:00:00.000Z"
-
-# payload["scale_teams"].append({
-# 	"team_id": team_id,
-# 	"begin_at": begin_at,
-# 	"user_id": evaluator_id
-# })
-
 # Prompt admin for evaluator, use that to find the ID.
 # For this we will use GET /v2/users/:id
 evaluator = input(f"{Fore.YELLOW}Type in the intra id of the evaluator: ").lower()

--- a/scale-teams/create_eval_session.py
+++ b/scale-teams/create_eval_session.py
@@ -1,0 +1,150 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+from datetime import datetime as dt, timedelta
+import os
+import json
+import colorama
+from colorama import Fore
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public projects"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+# payload = {}
+# payload["scale_teams"] = []
+
+# team_id = input("Input the team id: ")
+# evaluator_id = input("Input the id of the evaluator: ")
+# begin_at = "2024-04-11T12:00:00.000Z"
+
+# payload["scale_teams"].append({
+# 	"team_id": team_id,
+# 	"begin_at": begin_at,
+# 	"user_id": evaluator_id
+# })
+
+# Prompt admin for evaluator, use that to find the ID.
+# For this we will use GET /v2/users/:id
+evaluator = input(f"{Fore.YELLOW}Type in the intra id of the evaluator: ").lower()
+
+get_evaluator_req = oauth.get(f"{SITE}/v2/users/{evaluator}")
+if (get_evaluator_req.status_code == 200):
+	print(f"{Fore.GREEN}User {evaluator} found!")
+else:
+	print(f"{Fore.RED}User {evaluator} is not found!")
+	raise (Exception("User with intra ID is not found."))
+
+evaluator_data = json.loads(get_evaluator_req.text)
+evaluator_id = evaluator_data["id"]
+# print(f"{Fore.CYAN}User {evaluator} has id {evaluator_id}")
+
+# Prompt admin for evaluatee, then use that to find the team_id.
+# For this we will use GET /v2/users/:user_id/teams.
+evaluatee = input(f"{Fore.YELLOW}Type in the intra id of the evaluatee: ").lower()
+
+params = {
+	"page": {
+		"size": 10
+	},
+	"sort": "-id"
+}
+
+get_evaluatee_req = oauth.get(f"{SITE}/v2/users/{evaluatee}/teams", json=params)
+if (get_evaluatee_req.status_code == 200):
+	print(f"{Fore.GREEN}User {evaluatee} found!")
+else:
+	print(f"{Fore.RED}User {evaluatee} is not found!")
+	raise (Exception("User with intra ID is not found."))
+
+# From the list, return a list of the projects that are waiting for correction
+# and create an options array.
+evaluatee_teams_data = json.loads(get_evaluatee_req.text)
+options = []
+count = 0
+
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^15}+{'':-^15}+")
+print(f"{Fore.CYAN}|{'INDEX': ^7}|{'PROJECT': ^15}|{'TEAM_ID': ^15}|")
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^15}+{'':-^15}+")
+
+for item in evaluatee_teams_data:
+	if item['status'] != "waiting_for_correction" or item["project_gitlab_path"] is None:
+		continue
+	proj_name = item["project_gitlab_path"].split('/')[-1]
+	print(f"{Fore.CYAN}|{count: ^7}|{proj_name: ^15}|{item['id']: ^15}|")
+	options.append([proj_name, item['id']])
+	count += 1
+
+print(f"{Fore.CYAN}+{'':-^7}+{'':-^15}+{'':-^15}+" + '\n')
+
+# If there are no projects with the right status, exit prog.
+# Else if there is only one project, proceed with default option.
+# Else, ask admin which project to set an eval for.
+if count == 0:
+	print(f"{Fore.RED}[ ERROR ]: User {evaluatee} does not have any projects to evaluate!")
+	raise (Exception("No projects to evaluate."))
+else:
+	choice = input(f"{Fore.YELLOW}Type in the index of the project to set an evaluation (Default is {0}): ")
+	if choice == "":
+		choice = 0
+	else:
+		choice = int(choice)
+
+print(f"{Fore.CYAN}Chosen {evaluatee}'s {options[choice][0]} with id {options[choice][1]}")
+team_id = options[choice][1]
+
+# Get the starting time for the evaluation. Get the time in Malaysian time and correct to Paris time.
+# Paris time = Malaysia Time - 8 hours
+raw_date = input(f"{Fore.YELLOW}Type in the date of the eval in the format DD/MM/YYYY (Default is today): ")
+if raw_date == "":
+	raw_date = dt.now().strftime("%d/%m/%Y")
+
+raw_time = input(f"{Fore.YELLOW}Type in the start time of the eval in HH:MM (24h format): ")
+
+raw_start = f"{raw_date} {raw_time}"
+parsed_start = dt.strptime(raw_start, "%d/%m/%Y %H:%M")
+parsed_start = parsed_start - timedelta(hours=8)
+
+final_start = parsed_start.strftime("%Y-%m-%dT%H:%M:00.000Z")
+
+# Confirmation
+print(f"{Fore.CYAN}\nSimulated payload - Check for final details")
+print(f"{Fore.CYAN}team_id : {team_id}")
+print(f"{Fore.CYAN}user_id : {evaluator_id}")
+print(f"{Fore.CYAN}begin at : {final_start}")
+input(f"{Fore.RED}[ Confirmation ] - Press enter to confirm")
+
+# Build payload
+payload = {
+	"scale_teams" : [{
+		"team_id": team_id,
+		"begin_at": final_start,
+		"user_id": evaluator_id
+	}]
+}
+
+# Make the request
+response = oauth.post(f"{SITE}/v2/scale_teams/multiple_create", json=payload)
+
+if response.status_code == 201:
+	color = Fore.GREEN
+else:
+	color = Fore.RED
+print(f"{color} {response.status_code} {response.text}")

--- a/scale-teams/get_scale_team_by_id.py
+++ b/scale-teams/get_scale_team_by_id.py
@@ -1,0 +1,42 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+from datetime import datetime as dt, timedelta
+import os
+import json
+import colorama
+from colorama import Fore
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+response = oauth.get(f"{SITE}/v2/scale_teams/{6590977}")
+
+if response.status_code == 200:
+	color = Fore.GREEN
+else:
+	color = Fore.RED
+print(f"{color} {response.status_code} {response.text}")
+
+data = json.loads(response.text)
+
+with open(f"scale_teams.json", "w") as outfile:
+	json.dump(data, outfile, indent=4)

--- a/scale-teams/get_scale_team_by_id.py
+++ b/scale-teams/get_scale_team_by_id.py
@@ -28,7 +28,11 @@ token = oauth.fetch_token(
 	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
 )
 
-response = oauth.get(f"{SITE}/v2/scale_teams/{6590977}")
+# Get ID of the scale teams from running the script get_teams_of_user.py
+# Each evaluation session will have their own scale_teams_id.
+scale_teams_id = 6621457
+
+response = oauth.get(f"{SITE}/v2/scale_teams/{scale_teams_id}")
 
 if response.status_code == 200:
 	color = Fore.GREEN

--- a/teams/get_teams_of_user.py
+++ b/teams/get_teams_of_user.py
@@ -28,7 +28,7 @@ token = oauth.fetch_token(
 )
 
 # user_id = 172791
-user_id = "damdayan"
+user_id = "tcadet"
 
 # Load 30 "items" in one page.
 params = {
@@ -52,22 +52,25 @@ print(f"{color} {response.status_code}")
 # Load response into a JSON array and reverse it to arrange the project list from
 # most recent to least recent.
 data = json.loads(response.text)
-data = data[::-1]
+# data = data[::-1]
 
 # From the reversed list, take the 5 most recent submitted and Momo-graded projects that are not exams
 # and get the project name (project_gitlab_path), id, and Momo's comment to check for Norme anomalies (teams_uploads)
 
-count = 0
-for item in data:
-	if count == 5:
-		break
-	if item['status'] != 'finished' or item['project_gitlab_path'] is None or len(item['teams_uploads']) == 0:
-		continue
-	proj_name = str(item['project_gitlab_path']).split('/')[-1]
-	norme_count = len([1 for x in item['teams_uploads'][0]['comment'].split('|') if 'Norme' in x])
-	print(f"[{count}] : {proj_name} | {item['id']} | {norme_count}")
-	count += 1
+# count = 0
+# for item in data:
+# 	if count == 5:
+# 		break
+# 	if item['status'] != 'finished' or item['project_gitlab_path'] is None or len(item['teams_uploads']) == 0:
+# 		continue
+# 	proj_name = str(item['project_gitlab_path']).split('/')[-1]
+# 	norme_count = len([1 for x in item['teams_uploads'][0]['comment'].split('|') if 'Norme' in x])
+# 	print(f"[{count}] : {proj_name} | {item['id']} | {norme_count}")
+# 	count += 1
 
-json_obj = json.dumps(data, indent=4)
-with open(f"teams_of_{user_id}.json", "w") as outfile:
-	outfile.write(json_obj)
+# json_obj = json.dumps(data, indent=4)
+# with open(f"teams_of_{user_id}.json", "w") as outfile:
+# 	outfile.write(json_obj)
+
+with open("new_test.json", "w") as outfile:
+	json.dump(data, outfile, indent=4)

--- a/teams/patch_teams_uploads.py
+++ b/teams/patch_teams_uploads.py
@@ -1,0 +1,51 @@
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+from dotenv import load_dotenv
+import os
+import colorama
+from colorama import Fore
+
+colorama.init(autoreset=True)
+
+load_dotenv()
+
+# Patching teams uploads means modifying the mark that Moulinette has graded without
+# resubmitting the project. As far as we know, this would recalculate the
+# final mark of the project, but it does not recalculate the exp of the Cadet.
+
+# Yay API token stuff
+UID = os.getenv("42-UID")
+SECRET = os.getenv("42-SECRET")
+
+if UID == None or SECRET == None:
+	raise (Exception("Env variables are not defined!"))
+
+SITE = "https://api.intra.42.fr"
+SCOPE = "public projects"
+
+client = BackendApplicationClient(client_id=UID)
+oauth = OAuth2Session(client=client)
+
+token = oauth.fetch_token(
+	token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
+)
+
+payload = {
+	"teams_upload": {
+		"final_mark": "125",
+		"comment": "basic_tests: GNL OK | bonus_tests: GNL OK"
+    }
+}
+
+# response = oauth.get(f"{SITE}/v2/teams_uploads/{2150214}")
+
+response = oauth.patch(f"{SITE}/v2/teams_uploads/{1747919}", json=payload)
+
+# print(response.status_code)
+# print(response.text)
+
+if (response.status_code == 204):
+	color = Fore.GREEN
+else:
+	color = Fore.RED
+print(f"{color}{response.status_code} {response.text}")

--- a/users/get_users.py
+++ b/users/get_users.py
@@ -2,6 +2,7 @@ import requests
 from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
 from dotenv import load_dotenv
+import json
 import os
 
 load_dotenv()
@@ -26,9 +27,17 @@ token = oauth.fetch_token(
     token_url=f"{SITE}/oauth/token", client_id=UID, client_secret=SECRET, scope=SCOPE
 )
 
+# Determine who to stalk
+user_id = "zyeoh"
+
 # Make a request
-response = oauth.get(f"{SITE}/v2/users/wehuang")
+response = oauth.get(f"{SITE}/v2/users/{user_id}")
 
 # Print response status and content
 print(response.status_code)
-print(response.text)
+# print(response.text)
+
+data = json.loads(response.text)
+
+with open(f"user_{user_id}_data.json", "w") as outfile:
+    json.dump(data, outfile, indent=4)


### PR DESCRIPTION
Major changes/additions:
1. Added POST script to schedule eval sessions: ` scale-teams/create_eval_session.py`
2. Added POST script that auto creates Cadet exams for a week: `exams/create_cadet_exam.py`
3. Added POST script to add a student to an exam: `exam_users/post_exam_user.py`

Minor changes/additions:
1. Added PATCH script to patch Moulinette marks: `teams/patch_teams_uploads.py`
2. Added GET script for experience gained from a project submission: `experience/get_experience.py`
3. Added choice to create an exam in `exams/create_exam.py`
4. Added GET script for exam users: `exam_users/get_exam_users.py`